### PR TITLE
refactor: Migrate to Rust 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 
 after_success:
 - |
-  RUST_LOG=debug semantic-rs
+  CI=true RUST_LOG=debug semantic-rs
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "har"
 version = "0.2.0"
 authors = ["Sebastian Mandrean <sebastian.mandrean@gmail.com>"]
+edition = "2018"
 description = "A HTTP Archive format (HAR) serialization & deserialization library."
 license = "MIT"
 repository = "https://github.com/mandrean/har-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ url = "1.7.2"
 url_serde = "0.2.0"
 
 [dev-dependencies]
-glob = "0.2.11"
+glob = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-har = "0.2"
+har = "0.3"
 ```
 
 Use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ const MINIMUM_HAR12_VERSION: &str = ">= 1.2";
 
 /// Errors that HAR functions may return
 pub mod errors {
+    #![allow(deprecated)]
     error_chain! {
         foreign_links {
             Io(::std::io::Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 
 pub mod v1_2;
 pub mod v1_3;
-pub use errors::{Result, ResultExt};
+pub use crate::errors::{Result, ResultExt};
 
 const MINIMUM_HAR12_VERSION: &str = ">= 1.2";
 
@@ -35,7 +35,7 @@ pub mod errors {
             /// Deprecated - not generated anymore.
             UnsupportedSpecFileVersion(version: ::semver::Version) {
                 description("Unsupported HAR file version")
-                display("Unsupported HAR file version ({}). Expected {}", version, ::MINIMUM_HAR12_VERSION)
+                display("Unsupported HAR file version ({}). Expected {}", version, crate::MINIMUM_HAR12_VERSION)
             }
         }
     }


### PR DESCRIPTION
This PR is mainly about migrating to Rust 2018 (using `$ cargo fix --edition`).

The `error_chain` macro is now deprecated, but Rust's `failure` isn't a mature option either, so I'm silencing that deprecation warning for now.