### PR TITLE
fix: Revert "Check in lockfile"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 **/*.rs.bk
+Cargo.lock
 **/*.parsed
 **/*.pretty


### PR DESCRIPTION
This reverts commit 945247b46676d256dd33cdcf99af8297bc27fdd1, which checked in the lockfile.

It was a blunder from my side, forgetting that `har-rs` is a library and not a binary, and that different Rust conventions apply then.
