### PR TITLE
chore: Remove unused dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["har", "serialization", "deserialization", "json", "yaml"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
-semver = "0.11"
 thiserror = "1.0"
 
 [dependencies.serde_with]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ har = "0.7"
 
 Use
 ---
+Simplest possible example:
 ```rust
 use har::from_path;
 
@@ -29,6 +30,8 @@ fn main() {
 }
 ```
 
+See [docs.rs/har] for the full library API documentation.
+
 Contribute
 ----------
 This project follows [semver], [conventional commits] and semantic releasing using [mandrean/semantic-rs].
@@ -37,7 +40,8 @@ Note
 ----
 Inspired by [softprops/openapi](https://github.com/softprops/openapi).
 
-[har]: https://en.wikipedia.org/wiki/.har
-[semver]: https://semver.org/
 [conventional commits]: https://www.conventionalcommits.org
+[docs.rs/har]: https://docs.rs/har
+[har]: https://en.wikipedia.org/wiki/.har
 [mandrean/semantic-rs]: https://github.com/mandrean/semantic-rs
+[semver]: https://semver.org/


### PR DESCRIPTION
The `semver` package isn't used any more, so it should be removed.
