### PR TITLE
Some fields should be optional

### DIFF
--- a/src/v1_2/mod.rs
+++ b/src/v1_2/mod.rs
@@ -157,7 +157,7 @@ pub struct Content {
     pub size: i64,
     pub compression: Option<i64>,
     #[serde(rename = "mimeType")]
-    pub mime_type: String,
+    pub mime_type: Option<String>,
     pub text: Option<String>,
     pub encoding: Option<String>,
     pub comment: Option<String>,

--- a/src/v1_2/mod.rs
+++ b/src/v1_2/mod.rs
@@ -143,7 +143,7 @@ pub struct Response {
     pub headers: Vec<Headers>,
     pub content: Content,
     #[serde(rename = "redirectURL")]
-    pub redirect_url: String,
+    pub redirect_url: Option<String>,
     #[serde(rename = "headersSize")]
     pub headers_size: i64,
     #[serde(rename = "bodySize")]

--- a/src/v1_3/mod.rs
+++ b/src/v1_3/mod.rs
@@ -147,7 +147,7 @@ pub struct Response {
     pub headers: Vec<Headers>,
     pub content: Content,
     #[serde(rename = "redirectURL")]
-    pub redirect_url: String,
+    pub redirect_url: Option<String>,
     #[serde(rename = "headersSize")]
     pub headers_size: i64,
     #[serde(rename = "bodySize")]

--- a/src/v1_3/mod.rs
+++ b/src/v1_3/mod.rs
@@ -163,7 +163,7 @@ pub struct Content {
     pub size: i64,
     pub compression: Option<i64>,
     #[serde(rename = "mimeType")]
-    pub mime_type: String,
+    pub mime_type: Option<String>,
     pub text: Option<String>,
     pub encoding: Option<String>,
     pub comment: Option<String>,


### PR DESCRIPTION
*  I noticed that some fields populated by Charles Proxy (version 4.6.1 for certain) are set to `null`. These files include:
  * `response.redirectURL`
  * `content.mimeType`
* Changing these fields to `Option<String>` improves compatibility with default Charles Proxy output.