### PR TITLE
Fix firefox deserialization + fix from_reader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn from_reader<R>(read: R) -> Result<Har, Error>
 where
     R: Read,
 {
-    Ok(serde_yaml::from_reader::<R, Har>(read)?)
+    Ok(serde_json::from_reader::<R, Har>(read)?)
 }
 
 /// Serialize HAR spec to a YAML string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufReader, Read};
 use std::path::Path;
 
 pub mod v1_2;
@@ -54,7 +54,7 @@ pub fn from_path<P>(path: P) -> Result<Har, Error>
 where
     P: AsRef<Path>,
 {
-    from_reader(File::open(path)?)
+    from_reader(BufReader::new(File::open(path)?))
 }
 
 /// Deserialize a HAR from type which implements Read

--- a/src/v1_2/mod.rs
+++ b/src/v1_2/mod.rs
@@ -195,9 +195,12 @@ pub struct Timings {
     pub dns: Option<f64>,
     #[serde(default = "default_fsize_maybe")]
     pub connect: Option<f64>,
-    pub send: f64,
-    pub wait: f64,
-    pub receive: f64,
+    #[serde(default = "default_fsize_maybe")]
+    pub send: Option<f64>,
+    #[serde(default = "default_fsize_maybe")]
+    pub wait: Option<f64>,
+    #[serde(default = "default_fsize_maybe")]
+    pub receive: Option<f64>,
     #[serde(default = "default_fsize_maybe")]
     pub ssl: Option<f64>,
     pub comment: Option<String>,

--- a/src/v1_3/mod.rs
+++ b/src/v1_3/mod.rs
@@ -201,9 +201,12 @@ pub struct Timings {
     pub dns: Option<f64>,
     #[serde(default = "default_fsize_maybe")]
     pub connect: Option<f64>,
-    pub send: f64,
-    pub wait: f64,
-    pub receive: f64,
+    #[serde(default = "default_fsize_maybe")]
+    pub send: Option<f64>,
+    #[serde(default = "default_fsize_maybe")]
+    pub wait: Option<f64>,
+    #[serde(default = "default_fsize_maybe")]
+    pub receive: Option<f64>,
     #[serde(default = "default_fsize_maybe")]
     pub ssl: Option<f64>,
     pub comment: Option<String>,


### PR DESCRIPTION
This fixes two things:

1. Firefox does not write send, wait and receive in Timings. They have been changed to optional
2. from_reader was using serde_yaml instead of serde_json